### PR TITLE
Warn on non-conventional commit messages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Warn on non-Conventional commit messages
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const conventionalRegex = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?: .+/;
+            const eventName = context.eventName;
+            let commits = [];
+
+            if (eventName === 'pull_request') {
+              const pullNumber = context.payload.pull_request?.number;
+              if (!pullNumber) {
+                core.info('No pull request context detected.');
+              } else {
+                const { data } = await github.rest.pulls.listCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                  per_page: 250,
+                });
+                commits = data.map((entry) => entry.commit.message.split('\n')[0]);
+              }
+            } else if (eventName === 'push') {
+              const payloadCommits = context.payload.commits ?? [];
+              commits = payloadCommits.map((entry) => entry.message.split('\n')[0]);
+            } else {
+              core.info(`Commit message guidance not implemented for event: ${eventName}`);
+            }
+
+            if (!commits.length) {
+              core.info('No commit messages to inspect.');
+              return;
+            }
+
+            const invalid = commits.filter((message) => !conventionalRegex.test(message));
+
+            if (invalid.length) {
+              const formatted = invalid.map((message) => `- ${message}`).join('\n');
+              core.warning(`Commit messages that do not follow Conventional Commits were detected:\n${formatted}`);
+            } else {
+              core.info('All commit messages follow Conventional Commits.');
+            }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint all workspaces
+        run: npm run lint --workspaces --if-present
+
+      - name: Build all workspaces
+        run: npm run build --workspaces --if-present
+
+      - name: Test all workspaces
+        env:
+          CI: 'true'
+        run: npm test --workspaces --if-present -- --runInBand

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to CORTEX
+
+Thanks for helping improve CORTEX! This guide highlights the essentials so you can get productive quickly while keeping the platform safe and privacy-first.
+
+## Development Workflow
+
+1. Create a feature branch using the format `dev-unit-{feature}-{date}-{time}` (for example, `dev-unit-e2ee-index-2025-10-05-08-16-02`).
+2. Install project dependencies and verify the toolchain:
+   - Node.js 22 or newer
+   - Docker Engine and Docker Compose (for running the local stack)
+3. Run the standard checks before you push:
+   - `npm ci`
+   - `npm run lint`
+   - `npm run build`
+   - `npm test`
+4. Keep sensitive data encrypted end-to-end. Never log plaintext secrets or decrypted payloads on the server.
+
+## Commit Message Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org) specification. CI emits a warning when commits do not follow this format, so please keep your history compliant.
+
+A Conventional Commit message uses the structure:
+
+```
+<type>(<optional scope>): <summary>
+```
+
+- **type** is required and must be one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
+- **scope** is optional but recommended for clarity (for example, `api`, `web`, or `infra`).
+- **summary** should be concise, written in the imperative mood, and lowercase except for proper nouns.
+
+### Examples
+
+- `feat(api): add blind index tokens`
+- `fix(web): preserve offline queue on tab close`
+- `ci: warn on non-conventional commit messages`
+
+Following this convention keeps the history searchable and enables automated tooling (release notes, changelog generation, etc.).
+
+## Pull Requests
+
+- Keep PRs focused and include a summary of the changes, risks, and test coverage.
+- Highlight any security, privacy, or migration considerations.
+- If your change affects the UI, capture a screenshot of the relevant update.
+
+We appreciate your contributions and the care you take to keep user data private by default.


### PR DESCRIPTION
## Summary
- add a GitHub Actions step that fetches commits for pushes and PRs and emits warnings when messages are not Conventional Commits
- document the branch format, required checks, and Conventional Commit examples in CONTRIBUTING.md

## Testing
- not run (CI workflow and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e22c977b60832db6a62a013ddd42e2